### PR TITLE
Feat/6/TabBar UI 구현

### DIFF
--- a/LottoDairy.xcodeproj/project.pbxproj
+++ b/LottoDairy.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A732A55B99E0020F1DD /* HomeModuleFactory.swift */; };
 		80773A762A55BA1C0020F1DD /* ModuleFactoryImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A752A55BA1C0020F1DD /* ModuleFactoryImp.swift */; };
 		8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */; };
+		8080DDBE2A60540B00364CF1 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8080DDBD2A60540B00364CF1 /* TabBarView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +77,7 @@
 		80773A732A55B99E0020F1DD /* HomeModuleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleFactory.swift; sourceTree = "<group>"; };
 		80773A752A55BA1C0020F1DD /* ModuleFactoryImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleFactoryImp.swift; sourceTree = "<group>"; };
 		8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarComponents.swift; sourceTree = "<group>"; };
+		8080DDBD2A60540B00364CF1 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 		621503312A559C7300431BBB /* TabBarScene */ = {
 			isa = PBXGroup;
 			children = (
+				8080DDBC2A60530F00364CF1 /* Views */,
 				621503322A559C9600431BBB /* TabBarController.swift */,
 				621503342A559CB800431BBB /* TabBarCoordinator.swift */,
 				621503362A55A44900431BBB /* TabBarFlowProtocol.swift */,
@@ -257,6 +260,14 @@
 			path = HomeScene;
 			sourceTree = "<group>";
 		};
+		8080DDBC2A60530F00364CF1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8080DDBD2A60540B00364CF1 /* TabBarView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -332,6 +343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */,
+				8080DDBE2A60540B00364CF1 /* TabBarView.swift in Sources */,
 				621503302A559BB200431BBB /* CoordinatorFactoryImp.swift in Sources */,
 				621503332A559C9600431BBB /* TabBarController.swift in Sources */,
 				8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */,
@@ -502,7 +514,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -530,7 +542,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/LottoDairy.xcodeproj/project.pbxproj
+++ b/LottoDairy.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		80773A722A55AFF80020F1DD /* HomeFlowProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */; };
 		80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A732A55B99E0020F1DD /* HomeModuleFactory.swift */; };
 		80773A762A55BA1C0020F1DD /* ModuleFactoryImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A752A55BA1C0020F1DD /* ModuleFactoryImp.swift */; };
+		8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,6 +75,7 @@
 		80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowProtocol.swift; sourceTree = "<group>"; };
 		80773A732A55B99E0020F1DD /* HomeModuleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModuleFactory.swift; sourceTree = "<group>"; };
 		80773A752A55BA1C0020F1DD /* ModuleFactoryImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleFactoryImp.swift; sourceTree = "<group>"; };
+		8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarComponents.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 				621503322A559C9600431BBB /* TabBarController.swift */,
 				621503342A559CB800431BBB /* TabBarCoordinator.swift */,
 				621503362A55A44900431BBB /* TabBarFlowProtocol.swift */,
+				8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */,
 			);
 			path = TabBarScene;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */,
 				621503302A559BB200431BBB /* CoordinatorFactoryImp.swift in Sources */,
 				621503332A559C9600431BBB /* TabBarController.swift in Sources */,
+				8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */,
 				80773A6E2A55AE9E0020F1DD /* HomeCoordinator.swift in Sources */,
 				621503472A5BF12900431BBB /* OnboardingViewController.swift in Sources */,
 				621503452A5BF06100431BBB /* OnboardingFlowProtocol.swift in Sources */,
@@ -491,6 +495,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F2W258F5P6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LottoDairy/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -518,6 +523,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F2W258F5P6;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LottoDairy/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/LottoDairy.xcodeproj/project.pbxproj
+++ b/LottoDairy.xcodeproj/project.pbxproj
@@ -29,6 +29,10 @@
 		629C1F5D2A4ABD0F00540FA4 /* LottoDairy.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 629C1F5B2A4ABD0F00540FA4 /* LottoDairy.xcdatamodeld */; };
 		629C1F5F2A4ABD1000540FA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 629C1F5E2A4ABD1000540FA4 /* Assets.xcassets */; };
 		629C1F622A4ABD1000540FA4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 629C1F602A4ABD1000540FA4 /* LaunchScreen.storyboard */; };
+		805FA7072A6D834A00089070 /* LottoQRViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805FA7062A6D834A00089070 /* LottoQRViewController.swift */; };
+		805FA7092A6D84DC00089070 /* LottoQRModuleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805FA7082A6D84DC00089070 /* LottoQRModuleFactory.swift */; };
+		805FA70B2A6D853400089070 /* LottoQRFlowProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805FA70A2A6D853400089070 /* LottoQRFlowProtocol.swift */; };
+		805FA70D2A6D856D00089070 /* LottoQRCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805FA70C2A6D856D00089070 /* LottoQRCoordinator.swift */; };
 		80603AD62A4AC839003D5274 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD52A4AC839003D5274 /* Coordinator.swift */; };
 		80603AD82A4AC874003D5274 /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD72A4AC874003D5274 /* BaseCoordinator.swift */; };
 		80603ADA2A4E6FE2003D5274 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */; };
@@ -69,6 +73,10 @@
 		629C1F5E2A4ABD1000540FA4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		629C1F612A4ABD1000540FA4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		629C1F632A4ABD1000540FA4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		805FA7062A6D834A00089070 /* LottoQRViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRViewController.swift; sourceTree = "<group>"; };
+		805FA7082A6D84DC00089070 /* LottoQRModuleFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRModuleFactory.swift; sourceTree = "<group>"; };
+		805FA70A2A6D853400089070 /* LottoQRFlowProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRFlowProtocol.swift; sourceTree = "<group>"; };
+		805FA70C2A6D856D00089070 /* LottoQRCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRCoordinator.swift; sourceTree = "<group>"; };
 		80603AD52A4AC839003D5274 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		80603AD72A4AC874003D5274 /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -101,6 +109,7 @@
 				6215032C2A559B9700431BBB /* Imp */,
 				621503202A4E79D000431BBB /* CoordinatorFactory.swift */,
 				80773A732A55B99E0020F1DD /* HomeModuleFactory.swift */,
+				805FA7082A6D84DC00089070 /* LottoQRModuleFactory.swift */,
 				621503422A5BEF0400431BBB /* OnboardingModuleFactory.swift */,
 			);
 			path = Factories;
@@ -238,10 +247,21 @@
 				6215033D2A5BE91A00431BBB /* OnboardingScene */,
 				621503312A559C7300431BBB /* TabBarScene */,
 				80773A6C2A55AE8C0020F1DD /* HomeScene */,
+				805FA7052A6D832500089070 /* LottoQRScene */,
 				629C1F632A4ABD1000540FA4 /* Info.plist */,
 				629C1F5B2A4ABD0F00540FA4 /* LottoDairy.xcdatamodeld */,
 			);
 			path = LottoDairy;
+			sourceTree = "<group>";
+		};
+		805FA7052A6D832500089070 /* LottoQRScene */ = {
+			isa = PBXGroup;
+			children = (
+				805FA70C2A6D856D00089070 /* LottoQRCoordinator.swift */,
+				805FA7062A6D834A00089070 /* LottoQRViewController.swift */,
+				805FA70A2A6D853400089070 /* LottoQRFlowProtocol.swift */,
+			);
+			path = LottoQRScene;
 			sourceTree = "<group>";
 		};
 		80603AD22A4AC6F1003D5274 /* Application */ = {
@@ -367,16 +387,20 @@
 				80603AD62A4AC839003D5274 /* Coordinator.swift in Sources */,
 				80773A762A55BA1C0020F1DD /* ModuleFactoryImp.swift in Sources */,
 				80603AD82A4AC874003D5274 /* BaseCoordinator.swift in Sources */,
+				805FA70B2A6D853400089070 /* LottoQRFlowProtocol.swift in Sources */,
 				629C1F5D2A4ABD0F00540FA4 /* LottoDairy.xcdatamodeld in Sources */,
 				621503372A55A44900431BBB /* TabBarFlowProtocol.swift in Sources */,
 				621503432A5BEF0400431BBB /* OnboardingModuleFactory.swift in Sources */,
 				621503212A4E79D000431BBB /* CoordinatorFactory.swift in Sources */,
 				6215033F2A5BE93500431BBB /* OnboardingCoordinator.swift in Sources */,
 				80603ADE2A4E9FB0003D5274 /* RouterImp.swift in Sources */,
+				805FA7092A6D84DC00089070 /* LottoQRModuleFactory.swift in Sources */,
 				629C1F552A4ABD0F00540FA4 /* SceneDelegate.swift in Sources */,
 				621503352A559CB800431BBB /* TabBarCoordinator.swift in Sources */,
+				805FA70D2A6D856D00089070 /* LottoQRCoordinator.swift in Sources */,
 				80603ADA2A4E6FE2003D5274 /* AppCoordinator.swift in Sources */,
 				80773A722A55AFF80020F1DD /* HomeFlowProtocol.swift in Sources */,
+				805FA7072A6D834A00089070 /* LottoQRViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LottoDairy.xcodeproj/project.pbxproj
+++ b/LottoDairy.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		80603AD82A4AC874003D5274 /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD72A4AC874003D5274 /* BaseCoordinator.swift */; };
 		80603ADA2A4E6FE2003D5274 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */; };
 		80603ADE2A4E9FB0003D5274 /* RouterImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603ADD2A4E9FB0003D5274 /* RouterImp.swift */; };
+		8060B41F2A61A66800726C83 /* LottoQRButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8060B41E2A61A66800726C83 /* LottoQRButton.swift */; };
 		80773A6E2A55AE9E0020F1DD /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A6D2A55AE9E0020F1DD /* HomeCoordinator.swift */; };
 		80773A702A55AF770020F1DD /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A6F2A55AF770020F1DD /* HomeViewController.swift */; };
 		80773A722A55AFF80020F1DD /* HomeFlowProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */; };
@@ -71,6 +72,7 @@
 		80603AD72A4AC874003D5274 /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		80603ADD2A4E9FB0003D5274 /* RouterImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterImp.swift; sourceTree = "<group>"; };
+		8060B41E2A61A66800726C83 /* LottoQRButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRButton.swift; sourceTree = "<group>"; };
 		80773A6D2A55AE9E0020F1DD /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		80773A6F2A55AF770020F1DD /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowProtocol.swift; sourceTree = "<group>"; };
@@ -169,7 +171,6 @@
 				621503322A559C9600431BBB /* TabBarController.swift */,
 				621503342A559CB800431BBB /* TabBarCoordinator.swift */,
 				621503362A55A44900431BBB /* TabBarFlowProtocol.swift */,
-				8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */,
 			);
 			path = TabBarScene;
 			sourceTree = "<group>";
@@ -263,7 +264,9 @@
 		8080DDBC2A60530F00364CF1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8080DDBA2A604A0500364CF1 /* TabBarComponents.swift */,
 				8080DDBD2A60540B00364CF1 /* TabBarView.swift */,
+				8060B41E2A61A66800726C83 /* LottoQRButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -345,6 +348,7 @@
 				80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */,
 				8080DDBE2A60540B00364CF1 /* TabBarView.swift in Sources */,
 				621503302A559BB200431BBB /* CoordinatorFactoryImp.swift in Sources */,
+				8060B41F2A61A66800726C83 /* LottoQRButton.swift in Sources */,
 				621503332A559C9600431BBB /* TabBarController.swift in Sources */,
 				8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */,
 				80773A6E2A55AE9E0020F1DD /* HomeCoordinator.swift in Sources */,

--- a/LottoDairy.xcodeproj/project.pbxproj
+++ b/LottoDairy.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		80603ADA2A4E6FE2003D5274 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */; };
 		80603ADE2A4E9FB0003D5274 /* RouterImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80603ADD2A4E9FB0003D5274 /* RouterImp.swift */; };
 		8060B41F2A61A66800726C83 /* LottoQRButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8060B41E2A61A66800726C83 /* LottoQRButton.swift */; };
+		8060B4212A62DC2C00726C83 /* UIButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8060B4202A62DC2C00726C83 /* UIButton+Extensions.swift */; };
 		80773A6E2A55AE9E0020F1DD /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A6D2A55AE9E0020F1DD /* HomeCoordinator.swift */; };
 		80773A702A55AF770020F1DD /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A6F2A55AF770020F1DD /* HomeViewController.swift */; };
 		80773A722A55AFF80020F1DD /* HomeFlowProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */; };
@@ -73,6 +74,7 @@
 		80603AD92A4E6FE2003D5274 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		80603ADD2A4E9FB0003D5274 /* RouterImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterImp.swift; sourceTree = "<group>"; };
 		8060B41E2A61A66800726C83 /* LottoQRButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottoQRButton.swift; sourceTree = "<group>"; };
+		8060B4202A62DC2C00726C83 /* UIButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extensions.swift"; sourceTree = "<group>"; };
 		80773A6D2A55AE9E0020F1DD /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		80773A6F2A55AF770020F1DD /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		80773A712A55AFF80020F1DD /* HomeFlowProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowProtocol.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			children = (
 				621503512A5E6EC900431BBB /* UIFont+Extensions.swift */,
 				621503552A5E7B0500431BBB /* UIColor+Extensions.swift */,
+				8060B4202A62DC2C00726C83 /* UIButton+Extensions.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -348,6 +351,7 @@
 				80773A742A55B99E0020F1DD /* HomeModuleFactory.swift in Sources */,
 				8080DDBE2A60540B00364CF1 /* TabBarView.swift in Sources */,
 				621503302A559BB200431BBB /* CoordinatorFactoryImp.swift in Sources */,
+				8060B4212A62DC2C00726C83 /* UIButton+Extensions.swift in Sources */,
 				8060B41F2A61A66800726C83 /* LottoQRButton.swift in Sources */,
 				621503332A559C9600431BBB /* TabBarController.swift in Sources */,
 				8080DDBB2A604A0500364CF1 /* TabBarComponents.swift in Sources */,
@@ -518,7 +522,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -546,7 +550,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/LottoDairy/Application/AppCoordinator.swift
+++ b/LottoDairy/Application/AppCoordinator.swift
@@ -18,7 +18,8 @@ final class AppCoordinator: BaseCoordinator {
     }
     
     override func start() {
-        runOnboardingFlow()
+//        runOnboardingFlow()
+        runMainFlow()
     }
     
     private func runOnboardingFlow() {

--- a/LottoDairy/Coordinator/Factories/CoordinatorFactory.swift
+++ b/LottoDairy/Coordinator/Factories/CoordinatorFactory.swift
@@ -11,4 +11,5 @@ protocol CoordinatorFactory {
     func makeOnboardingCoordinator(router: Router) -> Coordinator & OnboardingCoordinatorFinishable
     func makeTabbarCoordinator() -> (configurator: Coordinator, toPresent: Presentable?)
     func makeHomeCoordinator(navigationController: UINavigationController?) -> Coordinator
+    func makeLottoQRCoordinator(navigationController: UINavigationController?) -> Coordinator
 }

--- a/LottoDairy/Coordinator/Factories/Imp/CoordinatorFactoryImp.swift
+++ b/LottoDairy/Coordinator/Factories/Imp/CoordinatorFactoryImp.swift
@@ -31,6 +31,16 @@ final class CoordinatorFactoryImp: CoordinatorFactory {
         
         return coordinator
     }
+
+    func makeLottoQRCoordinator(navigationController: UINavigationController?) -> Coordinator {
+        let coordinator = LottoQRCoordinator(
+            router: router(navigationController),
+            moduleFactory: ModuleFactoryImp(),
+            coordinatorFactory: CoordinatorFactoryImp()
+        )
+        
+        return coordinator
+    }
     
     private func router(_ navigationController: UINavigationController?) -> Router {
         let navigationController = navigationController ?? UINavigationController()

--- a/LottoDairy/Coordinator/Factories/Imp/ModuleFactoryImp.swift
+++ b/LottoDairy/Coordinator/Factories/Imp/ModuleFactoryImp.swift
@@ -5,7 +5,7 @@
 //  Created by Sunny on 2023/07/05.
 //
 
-final class ModuleFactoryImp: HomeModuleFactory, OnboardingModuleFactory {
+final class ModuleFactoryImp: HomeModuleFactory, OnboardingModuleFactory, LottoQRModuleFactory {
     
     func makeHomeFlow() -> HomeFlowProtocol {
         return HomeViewController()
@@ -13,5 +13,9 @@ final class ModuleFactoryImp: HomeModuleFactory, OnboardingModuleFactory {
     
     func makeOnboardingFlow() -> OnboardingFlowProtocol {
         return OnboardingViewController()
+    }
+
+    func makeLottoQRFlow() -> LottoQRFlowProtocol {
+        return LottoQRViewController()
     }
 }

--- a/LottoDairy/Coordinator/Factories/LottoQRModuleFactory.swift
+++ b/LottoDairy/Coordinator/Factories/LottoQRModuleFactory.swift
@@ -1,0 +1,11 @@
+//
+//  LottoQRModuleFactory.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/24.
+//
+
+protocol LottoQRModuleFactory {
+    func makeLottoQRFlow() -> LottoQRFlowProtocol
+}
+

--- a/LottoDairy/LottoQRScene/LottoQRCoordinator.swift
+++ b/LottoDairy/LottoQRScene/LottoQRCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  LottoQRCoordinator.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/24.
+//
+
+final class LottoQRCoordinator: BaseCoordinator {
+
+    private let router: Router
+    private let moduleFactory: LottoQRModuleFactory
+    private let coordinatorFactory: CoordinatorFactory
+
+    init(router: Router, moduleFactory: LottoQRModuleFactory, coordinatorFactory: CoordinatorFactory) {
+        self.router = router
+        self.moduleFactory = moduleFactory
+        self.coordinatorFactory = coordinatorFactory
+    }
+
+    override func start() {
+        var lottoQRFlow = moduleFactory.makeLottoQRFlow()
+        router.setRootModule(lottoQRFlow)
+    }
+
+}

--- a/LottoDairy/LottoQRScene/LottoQRFlowProtocol.swift
+++ b/LottoDairy/LottoQRScene/LottoQRFlowProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  LottoQRFlowProtocol.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/24.
+//
+
+protocol LottoQRFlowProtocol: Presentable {
+    
+}

--- a/LottoDairy/LottoQRScene/LottoQRViewController.swift
+++ b/LottoDairy/LottoQRScene/LottoQRViewController.swift
@@ -1,0 +1,18 @@
+//
+//  LottoQRViewController.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/24.
+//
+
+import UIKit
+
+final class LottoQRViewController: UIViewController, LottoQRFlowProtocol {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .red
+    }
+
+}

--- a/LottoDairy/Support/Extension/UIButton+Extensions.swift
+++ b/LottoDairy/Support/Extension/UIButton+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  UIButton+Extensions.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/15.
+//
+
+import UIKit
+
+extension UIButton {
+
+    func alignTextBelow(spacing: CGFloat = 4.0) {
+        guard let image = self.imageView?.image,
+              let titleLabel = self.titleLabel,
+              let titleText = titleLabel.text else {
+            return
+        }
+
+        let titleSize = titleText.size(withAttributes: [
+            NSAttributedString.Key.font: titleLabel.font as Any
+        ])
+
+        titleEdgeInsets = UIEdgeInsets(top: spacing, left: -image.size.width, bottom: -image.size.height, right: 0)
+        imageEdgeInsets = UIEdgeInsets(top: -(titleSize.height + spacing), left: 0, bottom: 0, right: -titleSize.width)
+    }
+}

--- a/LottoDairy/TabBarScene/TabBarComponents.swift
+++ b/LottoDairy/TabBarScene/TabBarComponents.swift
@@ -1,0 +1,44 @@
+//
+//  TabBarComponents.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/14.
+//
+
+enum TabBarComponents: CaseIterable {
+    case calendar
+    case home
+    case empty
+    case chart
+    case numbers
+    
+    var title: String {
+        switch self {
+        case .calendar:
+            return "달력"
+        case .home:
+            return "홈"
+        case .chart:
+            return "차트"
+        case .numbers:
+            return "번호 추첨"
+        case .empty:
+            return ""
+        }
+    }
+    
+    var systemName: String {
+        switch self {
+        case .calendar:
+            return "calendar.badge.plus"
+        case .home:
+            return "house"
+        case .chart:
+            return "chart.bar"
+        case .numbers:
+            return "number.circle"
+        case .empty:
+            return ""
+        }
+    }
+}

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -34,11 +34,11 @@ final class TabBarController: UITabBarController, TabBarFlowProtocol {
     }
     
     private func configureViewControllers() {
-        self.viewControllers = TabBarComponents.allCases.map { makeTabBarViewControllers($0) }
+        self.viewControllers = TabBarComponents.allCases.map { makeTabBarNavigationControllers($0) }
         selectedIndex = 1
     }
     
-    private func makeTabBarViewControllers(_ type: TabBarComponents) -> UINavigationController {
+    private func makeTabBarNavigationControllers(_ type: TabBarComponents) -> UINavigationController {
         let viewController = UINavigationController()
         viewController.tabBarItem.title = type.title
         viewController.tabBarItem.image = UIImage(systemName: type.systemName)

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -34,7 +34,7 @@ final class TabBarController: UITabBarController, TabBarFlowProtocol {
     }
     
     private func configureViewControllers() {
-        self.viewControllers = TabBarComponents.allCases.map { makeTabBarNavigationControllers($0) }
+        viewControllers = TabBarComponents.allCases.map { makeTabBarNavigationControllers($0) }
         selectedIndex = 1
     }
     

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -28,18 +28,25 @@ final class TabBarController: UITabBarController, UITabBarControllerDelegate, Ta
     }
     
     func configureViewControllers() {
-        let homeViewController = UINavigationController()
-        homeViewController.tabBarItem.title = "Home"
-        self.viewControllers = [homeViewController]
+        self.viewControllers = TabBarComponents.allCases.map { makeTabBarViewControllers($0) }
+        selectedIndex = 1
         
-        selectedIndex = 0
     }
     
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
         
-        if selectedIndex == 0 {
+        // 현재 문제 : 아래 코드가 실행되지 않아 flow 연결이 되지 않는다.
+        if selectedIndex == 1 {
             onHomeFlowSelect?(controller)
         }
+    }
+    
+    // MARK: Functions - Private
+    private func makeTabBarViewControllers(_ type: TabBarComponents) -> UINavigationController {
+        let viewController = UINavigationController()
+        viewController.tabBarItem.title = type.title
+        viewController.tabBarItem.image = UIImage(systemName: type.systemName)
+        return viewController
     }
 }

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class TabBarController: UITabBarController, UITabBarControllerDelegate, TabBarFlowProtocol {
+final class TabBarController: UITabBarController, TabBarFlowProtocol {
     
     var onViewWillAppear: ((UINavigationController) -> ())?
     
@@ -22,7 +22,7 @@ final class TabBarController: UITabBarController, UITabBarControllerDelegate, Ta
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if let controller = viewControllers?.first as? UINavigationController {
+        if let controller = viewControllers?[1] as? UINavigationController {
             onViewWillAppear?(controller)
         }
     }
@@ -30,23 +30,24 @@ final class TabBarController: UITabBarController, UITabBarControllerDelegate, Ta
     func configureViewControllers() {
         self.viewControllers = TabBarComponents.allCases.map { makeTabBarViewControllers($0) }
         selectedIndex = 1
-        
     }
     
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
-        
-        // 현재 문제 : 아래 코드가 실행되지 않아 flow 연결이 되지 않는다.
-        if selectedIndex == 1 {
-            onHomeFlowSelect?(controller)
-        }
-    }
-    
-    // MARK: Functions - Private
     private func makeTabBarViewControllers(_ type: TabBarComponents) -> UINavigationController {
         let viewController = UINavigationController()
         viewController.tabBarItem.title = type.title
         viewController.tabBarItem.image = UIImage(systemName: type.systemName)
         return viewController
+    }
+}
+
+extension TabBarController: UITabBarControllerDelegate {
+    
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
+        
+        // 현재 문제 : UITabBarControllerDelegate이 작동하지 않는다.
+        if selectedIndex == 1 {
+            onHomeFlowSelect?(controller)
+        }
     }
 }

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -16,6 +16,7 @@ final class TabBarController: UITabBarController, TabBarFlowProtocol {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        configureTabBar()
         configureViewControllers()
     }
     
@@ -27,7 +28,12 @@ final class TabBarController: UITabBarController, TabBarFlowProtocol {
         }
     }
     
-    func configureViewControllers() {
+    private func configureTabBar() {
+        setValue(TabBarView(frame: tabBar.frame), forKey: "tabBar")
+        delegate = self
+    }
+    
+    private func configureViewControllers() {
         self.viewControllers = TabBarComponents.allCases.map { makeTabBarViewControllers($0) }
         selectedIndex = 1
     }
@@ -44,10 +50,16 @@ extension TabBarController: UITabBarControllerDelegate {
     
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         guard let controller = viewControllers?[selectedIndex] as? UINavigationController else { return }
-        
-        // 현재 문제 : UITabBarControllerDelegate이 작동하지 않는다.
         if selectedIndex == 1 {
             onHomeFlowSelect?(controller)
         }
     }
+    
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        guard let selectedIndex = tabBarController.viewControllers?.firstIndex(of: viewController) else {
+            return true
+        }
+        return selectedIndex == 2 ? false : true
+    }
+
 }

--- a/LottoDairy/TabBarScene/TabBarController.swift
+++ b/LottoDairy/TabBarScene/TabBarController.swift
@@ -13,6 +13,8 @@ final class TabBarController: UITabBarController, TabBarFlowProtocol {
     
     var onHomeFlowSelect: ((UINavigationController) -> ())?
     
+    var onLottoQRFlowSelect: ((UINavigationController) -> ())?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/LottoDairy/TabBarScene/TabBarCoordinator.swift
+++ b/LottoDairy/TabBarScene/TabBarCoordinator.swift
@@ -25,8 +25,8 @@ final class TabBarCoordinator: BaseCoordinator {
     private func runHomeFlow() -> ((UINavigationController) -> ()) {
         return { [unowned self] navController in
           if navController.viewControllers.isEmpty == true {
-              let homeCoordinator = self.coordinatorFactory.makeHomeCoordinator(navigationController: navController)
-            self.addDependency(homeCoordinator)
+              let homeCoordinator = coordinatorFactory.makeHomeCoordinator(navigationController: navController)
+            addDependency(homeCoordinator)
             homeCoordinator.start()
           }
         }

--- a/LottoDairy/TabBarScene/TabBarCoordinator.swift
+++ b/LottoDairy/TabBarScene/TabBarCoordinator.swift
@@ -20,15 +20,27 @@ final class TabBarCoordinator: BaseCoordinator {
     override func start() {
         tabBarFlow.onViewWillAppear = runHomeFlow()
         tabBarFlow.onHomeFlowSelect = runHomeFlow()
+        tabBarFlow.onLottoQRFlowSelect = runLottoQRFlow()
     }
     
     private func runHomeFlow() -> ((UINavigationController) -> ()) {
         return { [unowned self] navController in
-          if navController.viewControllers.isEmpty == true {
-              let homeCoordinator = coordinatorFactory.makeHomeCoordinator(navigationController: navController)
-            addDependency(homeCoordinator)
-            homeCoordinator.start()
-          }
+            if navController.viewControllers.isEmpty == true {
+                let homeCoordinator = coordinatorFactory.makeHomeCoordinator(navigationController: navController)
+                addDependency(homeCoordinator)
+                homeCoordinator.start()
+            }
         }
     }
+
+    private func runLottoQRFlow() -> ((UINavigationController) -> ()) {
+        return { [unowned self] navController in
+            if navController.viewControllers.isEmpty == true {
+                let lottoQRCoordinator = coordinatorFactory.makeLottoQRCoordinator(navigationController: navController)
+                addDependency(lottoQRCoordinator)
+                lottoQRCoordinator.start()
+            }
+        }
+    }
+
 }

--- a/LottoDairy/TabBarScene/TabBarFlowProtocol.swift
+++ b/LottoDairy/TabBarScene/TabBarFlowProtocol.swift
@@ -10,4 +10,5 @@ import UIKit
 protocol TabBarFlowProtocol: AnyObject {
     var onViewWillAppear: ((UINavigationController) -> ())? { get set }
     var onHomeFlowSelect: ((UINavigationController) -> ())? { get set }
+    var onLottoQRFlowSelect: ((UINavigationController) -> ())? { get set }
 }

--- a/LottoDairy/TabBarScene/Views/LottoQRButton.swift
+++ b/LottoDairy/TabBarScene/Views/LottoQRButton.swift
@@ -9,8 +9,6 @@ import UIKit
 
 final class LottoQRButton: UIButton {
 
-    private var buttonConfiguration = UIButton.Configuration.filled()
-
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -24,25 +22,23 @@ final class LottoQRButton: UIButton {
     }
 
     private func configureLottoQRButton() {
-        buttonConfiguration.baseBackgroundColor = .designSystem(.mainBlue)
-        self.configuration = buttonConfiguration
+        self.backgroundColor = .designSystem(.mainBlue)
+        self.alignTextBelow(spacing: 7)
     }
 
     private func configureTextAttribute() {
-        var textAttribute = AttributedString(TabBarComponents.LottoQR.title)
-        textAttribute.font = .gmarketSans(size: .caption, weight: .bold)
+        let attribute: [NSAttributedString.Key: Any] = [
+            .font: UIFont.gmarketSans(size: .caption, weight: .bold),
+            .foregroundColor: UIColor.white
+        ]
+        let attributedString = NSAttributedString(string: TabBarComponents.LottoQR.title, attributes: attribute)
 
-        buttonConfiguration.attributedSubtitle = textAttribute
-        buttonConfiguration.titleAlignment = .center
+        setAttributedTitle(attributedString, for: .normal)
     }
 
     private func configureImage() {
-        let image = UIImage(systemName: TabBarComponents.LottoQR.systemName)
-        let imageConfiguration = UIImage.SymbolConfiguration(pointSize: 20)
-
-        buttonConfiguration.preferredSymbolConfigurationForImage = imageConfiguration
-        buttonConfiguration.image = image
-        buttonConfiguration.imagePadding = 5
-        buttonConfiguration.imagePlacement = .top
+        let imageConfiguration = UIImage.SymbolConfiguration(pointSize: 25)
+        let image = UIImage(systemName: TabBarComponents.LottoQR.systemName, withConfiguration: imageConfiguration)
+        self.setImage(image, for: .normal)
     }
 }

--- a/LottoDairy/TabBarScene/Views/LottoQRButton.swift
+++ b/LottoDairy/TabBarScene/Views/LottoQRButton.swift
@@ -22,8 +22,8 @@ final class LottoQRButton: UIButton {
     }
 
     private func configureLottoQRButton() {
-        self.backgroundColor = .designSystem(.mainBlue)
-        self.alignTextBelow(spacing: 7)
+        backgroundColor = .designSystem(.mainBlue)
+        alignTextBelow(spacing: 7)
     }
 
     private func configureTextAttribute() {
@@ -39,6 +39,6 @@ final class LottoQRButton: UIButton {
     private func configureImage() {
         let imageConfiguration = UIImage.SymbolConfiguration(pointSize: 25)
         let image = UIImage(systemName: TabBarComponents.LottoQR.systemName, withConfiguration: imageConfiguration)
-        self.setImage(image, for: .normal)
+        setImage(image, for: .normal)
     }
 }

--- a/LottoDairy/TabBarScene/Views/LottoQRButton.swift
+++ b/LottoDairy/TabBarScene/Views/LottoQRButton.swift
@@ -1,0 +1,48 @@
+//
+//  LottoQRButton.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/15.
+//
+
+import UIKit
+
+final class LottoQRButton: UIButton {
+
+    private var buttonConfiguration = UIButton.Configuration.filled()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configureTextAttribute()
+        configureImage()
+        configureLottoQRButton()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureLottoQRButton() {
+        buttonConfiguration.baseBackgroundColor = .designSystem(.mainBlue)
+        self.configuration = buttonConfiguration
+    }
+
+    private func configureTextAttribute() {
+        var textAttribute = AttributedString(TabBarComponents.LottoQR.title)
+        textAttribute.font = .gmarketSans(size: .caption, weight: .bold)
+
+        buttonConfiguration.attributedSubtitle = textAttribute
+        buttonConfiguration.titleAlignment = .center
+    }
+
+    private func configureImage() {
+        let image = UIImage(systemName: TabBarComponents.LottoQR.systemName)
+        let imageConfiguration = UIImage.SymbolConfiguration(pointSize: 20)
+
+        buttonConfiguration.preferredSymbolConfigurationForImage = imageConfiguration
+        buttonConfiguration.image = image
+        buttonConfiguration.imagePadding = 5
+        buttonConfiguration.imagePlacement = .top
+    }
+}

--- a/LottoDairy/TabBarScene/Views/TabBarComponents.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarComponents.swift
@@ -41,4 +41,10 @@ enum TabBarComponents: CaseIterable {
             return ""
         }
     }
+
+    enum LottoQR {
+        static let title = "로또 QR"
+        static let systemName = "qrcode"
+    }
+
 }

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -46,23 +46,23 @@ final class TabBarView: UITabBar {
     }
 
     private func configureTabBar() {
-        self.barStyle = .black
-        self.tintColor = .designSystem(.white)
-        self.items?.forEach { $0.setTitleTextAttributes(
+        barStyle = .black
+        tintColor = .designSystem(.white)
+        items?.forEach { $0.setTitleTextAttributes(
             [.font : UIFont.gmarketSans(size: .caption, weight: .medium)],
             for: .normal)
         }
     }
 
     private func configureLottoQRButton() {
-        let x = (self.bounds.width / 2) - Constraints.halfLottoQRButtonSize
+        let x = (bounds.width / 2) - Constraints.halfLottoQRButtonSize
         let lottoQRButton = LottoQRButton(frame: CGRect(x: x,
                                                         y: -Constraints.halfLottoQRButtonSize,
                                                         width: Constraints.lottoQRButtonSize,
                                                         height: Constraints.lottoQRButtonSize))
         lottoQRButton.clipsToBounds = true
         lottoQRButton.layer.cornerRadius = Constraints.halfLottoQRButtonSize
-        self.addSubview(lottoQRButton)
+        addSubview(lottoQRButton)
     }
 
     private func configureCurveShape() {
@@ -71,9 +71,9 @@ final class TabBarView: UITabBar {
         shapeLayer.fillColor = UIColor.designSystem(.gray2B2C35)?.cgColor
 
         if let oldShapeLayer = self.shapeLayer {
-            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
+            layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
         } else {
-            self.layer.insertSublayer(shapeLayer, at: .zero)
+            layer.insertSublayer(shapeLayer, at: .zero)
         }
         self.shapeLayer = shapeLayer
     }

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -17,12 +17,16 @@ final class TabBarView: UITabBar {
         static let pathRadius: CGFloat = halfLottoQRButtonSize + 5
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
         configureTabBar()
     }
-    
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         var sizeThatFits = super.sizeThatFits(size)
         sizeThatFits.height = sizeThatFits.height + 5

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -52,9 +52,11 @@ final class TabBarView: UITabBar {
     private func configureTabBar() {
         barStyle = .black
         tintColor = .designSystem(.white)
-        items?.forEach { $0.setTitleTextAttributes(
+        items?.forEach { tabBarItem in
+            tabBarItem.setTitleTextAttributes(
             [.font : UIFont.gmarketSans(size: .caption, weight: .medium)],
-            for: .normal)
+            for: .normal
+            )
         }
     }
 

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -8,7 +8,17 @@
 import UIKit
 
 final class TabBarView: UITabBar {
-    
+
+    private var shapeLayer: CALayer?
+
+    private let lottoQRButton = LottoQRButton()
+
+    enum Constraints {
+        static let lottoQRButtonSize: CGFloat = 80
+        static let halfLottoQRButtonSize: CGFloat = 80 / 2
+        static let pathRadius: CGFloat = halfLottoQRButtonSize + 5
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         
@@ -16,18 +26,71 @@ final class TabBarView: UITabBar {
     }
     
     override func sizeThatFits(_ size: CGSize) -> CGSize {
-        
         var sizeThatFits = super.sizeThatFits(size)
         sizeThatFits.height = sizeThatFits.height + 5
         
         return sizeThatFits
     }
-    
-    private func configureTabBar() {
-        self.backgroundColor = .designSystem(.gray2B2C35)
-        self.barStyle = .black
-        self.tintColor = .designSystem(.white)
-        self.items?.forEach { $0.setTitleTextAttributes([.font : UIFont.gmarketSans(size: .caption, weight: .medium)], for: .normal)}
+
+    override func draw(_ rect: CGRect) {
+        configureCurveShape()
+        configureLottoQRButton()
     }
 
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard !clipsToBounds && !isHidden && alpha > .zero else { return nil }
+
+        return self.lottoQRButton.frame.contains(point) ? self.lottoQRButton : super.hitTest(point, with: event)
+    }
+
+    private func configureTabBar() {
+        self.barStyle = .black
+        self.tintColor = .designSystem(.white)
+        self.items?.forEach { $0.setTitleTextAttributes(
+            [.font : UIFont.gmarketSans(size: .caption, weight: .medium)],
+            for: .normal)
+        }
+    }
+
+    private func configureLottoQRButton() {
+        self.addSubview(lottoQRButton)
+
+        let x = (self.bounds.width / 2) - Constraints.halfLottoQRButtonSize
+        lottoQRButton.frame = CGRect(x: x,
+                                     y: -Constraints.halfLottoQRButtonSize,
+                                     width: Constraints.lottoQRButtonSize,
+                                     height: Constraints.lottoQRButtonSize)
+        lottoQRButton.clipsToBounds = true
+        lottoQRButton.layer.cornerRadius = Constraints.halfLottoQRButtonSize
+    }
+
+    private func configureCurveShape() {
+        let shapeLayer = CAShapeLayer()
+        shapeLayer.path = createPath()
+        shapeLayer.fillColor = UIColor.designSystem(.gray2B2C35)?.cgColor
+
+        if let oldShapeLayer = self.shapeLayer {
+            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
+        } else {
+            self.layer.insertSublayer(shapeLayer, at: .zero)
+        }
+        self.shapeLayer = shapeLayer
+    }
+
+    private func createPath() -> CGPath {
+        let path = UIBezierPath()
+
+        path.move(to: .zero)
+        let halfPoint = CGPoint(x: frame.width / 2, y: .zero)
+        path.addArc(withCenter: halfPoint,
+                    radius: Constraints.pathRadius,
+                    startAngle: .pi,
+                    endAngle: .zero,
+                    clockwise: false)
+        path.addLine(to: CGPoint(x: frame.width, y: .zero))
+        path.addLine(to: CGPoint(x: frame.width, y: frame.height))
+        path.addLine(to: CGPoint(x: .zero, y: frame.height))
+
+        return path.cgPath
+    }
 }

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -1,0 +1,33 @@
+//
+//  TabBarView.swift
+//  LottoDairy
+//
+//  Created by Sunny on 2023/07/14.
+//
+
+import UIKit
+
+final class TabBarView: UITabBar {
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        configureTabBar()
+    }
+    
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        
+        var sizeThatFits = super.sizeThatFits(size)
+        sizeThatFits.height = sizeThatFits.height + 5
+        
+        return sizeThatFits
+    }
+    
+    private func configureTabBar() {
+        self.backgroundColor = .designSystem(.gray2B2C35)
+        self.barStyle = .black
+        self.tintColor = .designSystem(.white)
+        self.items?.forEach { $0.setTitleTextAttributes([.font : UIFont.gmarketSans(size: .caption, weight: .medium)], for: .normal)}
+    }
+
+}

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -11,7 +11,7 @@ final class TabBarView: UITabBar {
 
     private var shapeLayer: CALayer?
 
-    enum Constraints {
+    private enum Constraints {
         static let lottoQRButtonSize: CGFloat = 80
         static let halfLottoQRButtonSize: CGFloat = 80 / 2
         static let pathRadius: CGFloat = halfLottoQRButtonSize + 5

--- a/LottoDairy/TabBarScene/Views/TabBarView.swift
+++ b/LottoDairy/TabBarScene/Views/TabBarView.swift
@@ -11,8 +11,6 @@ final class TabBarView: UITabBar {
 
     private var shapeLayer: CALayer?
 
-    private let lottoQRButton = LottoQRButton()
-
     enum Constraints {
         static let lottoQRButtonSize: CGFloat = 80
         static let halfLottoQRButtonSize: CGFloat = 80 / 2
@@ -38,9 +36,13 @@ final class TabBarView: UITabBar {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard !clipsToBounds && !isHidden && alpha > .zero else { return nil }
-
-        return self.lottoQRButton.frame.contains(point) ? self.lottoQRButton : super.hitTest(point, with: event)
+        guard !clipsToBounds && !isHidden && alpha > 0 else { return nil }
+        for member in subviews.reversed() {
+            let subPoint = member.convert(point, from: self)
+            guard let result = member.hitTest(subPoint, with: event) else { continue }
+            return result
+        }
+        return nil
     }
 
     private func configureTabBar() {
@@ -53,15 +55,14 @@ final class TabBarView: UITabBar {
     }
 
     private func configureLottoQRButton() {
-        self.addSubview(lottoQRButton)
-
         let x = (self.bounds.width / 2) - Constraints.halfLottoQRButtonSize
-        lottoQRButton.frame = CGRect(x: x,
-                                     y: -Constraints.halfLottoQRButtonSize,
-                                     width: Constraints.lottoQRButtonSize,
-                                     height: Constraints.lottoQRButtonSize)
+        let lottoQRButton = LottoQRButton(frame: CGRect(x: x,
+                                                        y: -Constraints.halfLottoQRButtonSize,
+                                                        width: Constraints.lottoQRButtonSize,
+                                                        height: Constraints.lottoQRButtonSize))
         lottoQRButton.clipsToBounds = true
         lottoQRButton.layer.cornerRadius = Constraints.halfLottoQRButtonSize
+        self.addSubview(lottoQRButton)
     }
 
     private func configureCurveShape() {


### PR DESCRIPTION
![스크린샷 2023-07-15 오후 11 30 39](https://github.com/seunghyunCheon/LottoDiary/assets/85678496/cf33a9f4-0005-4b0d-95b2-3d24d15eea5b)

- TabBarComponents : TabBar에서 각 탭마다의 요소를 갖고 있는 타입
     ```swift
     private func configureViewControllers() {
        self.viewControllers = TabBarComponents.allCases.map { makeTabBarViewControllers($0) }
        selectedIndex = 1
    }
    ```  
    - TabBarController에서 각 탭의 NavigationController를 설정할 때, 코드 나열보단 map을 사용하는 것이 더 편리할 것이라 생각했다.
    - 만약 새로운 탭이 추가된다 해도 TabBarComponents의 요소만 추가하면 되기 때문에 변경에 용이하다.

- TabBarView : Custom한 UITabBar
- LottoQRButton : TabBar 가운데 영역에 있는 LottoQR 버튼
- TabBarController
     ```swift
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
        guard let selectedIndex = tabBarController.viewControllers?.firstIndex(of: viewController) else {
            return true
        }
        return selectedIndex == 2 ? false : true
    }    
    ```  
    - TabBar의 index가 2인 tabBarItem은 로또QR 버튼을 위한 빈 tabBarItem이 들어가 있다.
    - 해당 탭바는 단순히 로또QR 버튼 공간을 위해 넣어 놨기 때문에 해당 영역은 사용자 입력이 비활성화 되어야 한다.
    ```swift
    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
        guard !clipsToBounds && !isHidden && alpha > 0 else { return nil }
        for member in subviews.reversed() {
            let subPoint = member.convert(point, from: self)
            guard let result = member.hitTest(subPoint, with: event) else { continue }
            return result
        }
        return nil
    }
    ````
    - 로또QR 버튼의 터치는 TabBarView에서 hitTest를 재정의해 해결했다.
    - TabBarView에서 subviews를 터치 이벤트 대상으로 지정했기 때문에 index==2인 영역은 터치를 비활성화 했지만 로또QR 버튼은 사용자 입력이 가능하다.